### PR TITLE
Add Multicall4

### DIFF
--- a/src/Multicall4.sol
+++ b/src/Multicall4.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+import { Multicall3 } from "./Multicall3.sol";
+
+/// @title Multicall4
+/// @notice Extension of Multicall3 with additional hooks to drain non-deterministally obtained tokens during execution
+contract Multicall4 is Multicall3 {
+    /// @notice Send the full ether balance to the sender
+    /// @dev Used to sweep any non-deterministically obtained ether during the course of aggregate execution
+    function drain() external payable {
+        payable(msg.sender).transfer(address(this).balance);
+    }
+
+    /// @notice Send the full balance of `token` to the sender
+    /// @dev Used to sweep any non-deterministically obtained tokens during the course of aggregate execution
+    function drain(IERC20 token) external payable {
+        token.transfer(msg.sender, token.balanceOf(address(this)));
+    }
+}
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}

--- a/src/Multicall4.sol
+++ b/src/Multicall4.sol
@@ -8,14 +8,17 @@ import { Multicall3 } from "./Multicall3.sol";
 contract Multicall4 is Multicall3 {
     /// @notice Send the full ether balance to the sender
     /// @dev Used to sweep any non-deterministically obtained ether during the course of aggregate execution
-    function drain() external payable {
-        payable(msg.sender).transfer(address(this).balance);
+    /// @param receiver The address to send the ether to
+    function drain(address payable receiver) public payable {
+        receiver.transfer(address(this).balance);
     }
 
     /// @notice Send the full balance of `token` to the sender
     /// @dev Used to sweep any non-deterministically obtained tokens during the course of aggregate execution
-    function drain(IERC20 token) external payable {
-        token.transfer(msg.sender, token.balanceOf(address(this)));
+    /// @param token The token to drain
+    /// @param receiver The address to send the tokens to
+    function drain(IERC20 token, address receiver) public payable {
+        token.transfer(receiver, token.balanceOf(address(this)));
     }
 }
 

--- a/src/test/Multicall4.t.sol
+++ b/src/test/Multicall4.t.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.12;
+
+import { Test } from "forge-std/Test.sol";
+import { Multicall4, IERC20 } from "../Multicall4.sol";
+import "forge-std/console.sol";
+
+contract Multicall4Test is Test {
+  IERC20 mockToken = IERC20(makeAddr("mockToken"));
+  Multicall4 multicall;
+
+  /// @notice Setups up the testing suite
+  function setUp() public {
+    multicall = new Multicall4();
+  }
+
+  /// >>>>>>>>>>>>>>>>>>>>>  DRAIN TESTS  <<<<<<<<<<<<<<<<<<<<< ///
+
+  function testDrain() public {
+    vm.deal(address(this), 1 ether);
+
+    Multicall4.Call[] memory noop;
+    multicall.aggregate{value: 1 ether}(noop);
+    assertEq(address(multicall).balance, 1 ether);
+
+    multicall.drain();
+
+    assertEq(address(multicall).balance, 0);
+    assertEq(address(this).balance, 1 ether);
+  }
+
+  function testDrainToken() public {
+    vm.mockCall(
+        address(mockToken),
+        abi.encodeWithSelector(IERC20.balanceOf.selector, address(multicall)),
+        abi.encode(1 ether)
+    );
+    vm.mockCall(
+        address(mockToken),
+        abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1 ether),
+        abi.encode(true)
+    );
+
+    vm.expectCall(
+      address(mockToken), 0, abi.encodeWithSelector(IERC20.balanceOf.selector, address(multicall))
+    );
+    vm.expectCall(
+      address(mockToken), 0, abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1 ether)
+    );
+
+    multicall.drain(mockToken);
+  }
+
+  receive() external payable { }
+}

--- a/src/test/Multicall4.t.sol
+++ b/src/test/Multicall4.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.12;
 
 import { Test } from "forge-std/Test.sol";
 import { Multicall4, IERC20 } from "../Multicall4.sol";
-import "forge-std/console.sol";
 
 contract Multicall4Test is Test {
   IERC20 mockToken = IERC20(makeAddr("mockToken"));
@@ -23,7 +22,23 @@ contract Multicall4Test is Test {
     multicall.aggregate{value: 1 ether}(noop);
     assertEq(address(multicall).balance, 1 ether);
 
-    multicall.drain();
+    multicall.drain(payable(this));
+
+    assertEq(address(multicall).balance, 0);
+    assertEq(address(this).balance, 1 ether);
+  }
+
+  function testDrainAggregate() public {
+    vm.deal(address(this), 1 ether);
+
+    Multicall4.Call[] memory noop;
+    multicall.aggregate{value: 1 ether}(noop);
+    assertEq(address(multicall).balance, 1 ether);
+
+    Multicall4.Call[] memory calls = new Multicall4.Call[](1);
+    calls[0].target = address(multicall);
+    calls[0].callData = abi.encodeWithSignature("drain(address)", payable(this));
+    multicall.aggregate(calls);
 
     assertEq(address(multicall).balance, 0);
     assertEq(address(this).balance, 1 ether);
@@ -48,7 +63,32 @@ contract Multicall4Test is Test {
       address(mockToken), 0, abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1 ether)
     );
 
-    multicall.drain(mockToken);
+    multicall.drain(mockToken, address(this));
+  }
+
+  function testDrainTokenAggregate() public {
+    vm.mockCall(
+        address(mockToken),
+        abi.encodeWithSelector(IERC20.balanceOf.selector, address(multicall)),
+        abi.encode(1 ether)
+    );
+    vm.mockCall(
+        address(mockToken),
+        abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1 ether),
+        abi.encode(true)
+    );
+
+    vm.expectCall(
+      address(mockToken), 0, abi.encodeWithSelector(IERC20.balanceOf.selector, address(multicall))
+    );
+    vm.expectCall(
+      address(mockToken), 0, abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1 ether)
+    );
+
+    Multicall4.Call[] memory calls = new Multicall4.Call[](1);
+    calls[0].target = address(multicall);
+    calls[0].callData = abi.encodeWithSignature("drain(address,address)", mockToken, payable(this));
+    multicall.aggregate(calls);
   }
 
   receive() external payable { }


### PR DESCRIPTION
Adds an extension to `Multicall3` that adds the ability to drain ether and tokens.

This can be used by keepers to claim any accrued, but non-deterministic rewards at the and of an aggregate execution.